### PR TITLE
Fix Broken Installation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 ## 🚀 Getting Started
 
 - [Documentation](https://airtrail.johan.ohly.dk/docs/overview/introduction)
-- [Installation](https://airtrail.johan.ohly.dk/docs/overview/quick-start/)
+- [Installation](https://airtrail.johan.ohly.dk/docs/overview/quick-start)
 - [About](https://airtrail.johan.ohly.dk/docs/overview/introduction)
 
 ## 🤝 Contributing


### PR DESCRIPTION
Trivial fix for broken installation link in the README.md. `https://airtrail.johan.ohly.dk/docs/overview/quick-start/` does not exist. The url should be `https://airtrail.johan.ohly.dk/docs/overview/quick-start`.

